### PR TITLE
organizationId is not needed for ip based login in Salesforce

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -84,11 +84,11 @@ class Salesforce(object):
             else:
                 self.sf_instance = kwargs['instance']
 
-        elif 'username' in kwargs and 'password' in kwargs and 'organizationId' in kwargs:
+        elif 'username' in kwargs and 'password' in kwargs:
             self.auth_type = 'ipfilter'
             username = kwargs['username']
             password = kwargs['password']
-            organizationId = kwargs['organizationId']
+            organizationId = kwargs['organizationId'] if 'organizationId' in kwargs else None
 
             # Pass along the username/password to our login helper
             self.session_id, self.sf_instance = SalesforceLogin(

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -64,7 +64,7 @@ def SalesforceLogin(**kwargs):
         </env:Envelope>""".format(username=username, password=password, token=security_token)
 
     # Check if IP Filtering is used in cojuction with organizationId
-    elif 'organizationId' in kwargs:
+    elif 'organizationId' in kwargs and kwargs['organizationId']:
         organizationId = kwargs['organizationId']
 
         # IP Filtering Login Soap request body
@@ -89,7 +89,26 @@ def SalesforceLogin(**kwargs):
             </soapenv:Body>
         </soapenv:Envelope>""".format(
             username=username, password=password, organizationId=organizationId)
-
+    elif 'organizationId' in kwargs:
+        # IP Filtering for non self-service users
+        login_soap_request_body = """<?xml version="1.0" encoding="utf-8" ?>
+        <soapenv:Envelope
+                xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                xmlns:urn="urn:partner.soap.sforce.com">
+            <soapenv:Header>
+                <urn:CallOptions>
+                    <urn:client>RestForce</urn:client>
+                    <urn:defaultNamespace>sf</urn:defaultNamespace>
+                </urn:CallOptions>
+            </soapenv:Header>
+            <soapenv:Body>
+                <urn:login>
+                    <urn:username>{username}</urn:username>
+                    <urn:password>{password}</urn:password>
+                </urn:login>
+            </soapenv:Body>
+        </soapenv:Envelope>""".format(
+            username=username, password=password)
     else:
         except_code = 'INVALID AUTH'
         except_msg = 'You must submit either a security token or organizationId for authentication'


### PR DESCRIPTION
organizationId is not needed for ip based login in Salesforce, so simple-salesforce should allow login with just user and pass as it is enough when you have set your ip correctly in Salesforce.