### PR TITLE
totalSize is already the right total on first call, no need to add

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -202,7 +202,7 @@ class Salesforce(object):
             return None
         else:
             return json_result
-        
+
     # Search Functions
     def search(self, search):
         """Returns the result of a Salesforce search as a dict decoded from
@@ -319,7 +319,6 @@ class Salesforce(object):
             else:
                 result = self.query_more(previous_result['nextRecordsUrl'],
                                          identifier_is_url=True, **kwargs)
-                result['totalSize'] += previous_result['totalSize']
                 # Include the new list of records with the previous list
                 previous_result['records'].extend(result['records'])
                 result['records'] = previous_result['records']


### PR DESCRIPTION
No need to keep adding totalSize to itself in `query_all`:

```python
In [1]: from simple_salesforce import Salesforce

In [2]: sf = Salesforce(username="USERNAME", password="PASSWORD", security_token="TOKEN")

In [3]: ids = sf.query("SELECT id FROM account")

In [4]: ids['totalSize']
Out[4]: 612069

In [5]: len(ids['records'])
Out[5]: 2000
```