### PR TITLE
Custom session injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ build/
 dist/
 *.egg-info
 *.egg
+*.eggs
 .idea

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,23 @@ For example:
 
 Note that specifying if you want to use a sandbox is only necessary if you are using the built-in username/password/security token authentication and is used exclusively during the authentication step.
 
+When instantiating a `Salesforce` object, it's also possible to include an
+instance of :class:`~requests.Session()`. This is to allow for specialized
+session handling not otherwise exposed by simple_salesoforce.
+
+For example:
+
+.. code-block:: python
+
+   from simple_salesforce import Salesforce
+   import requests
+
+   session = requests.Session()
+   # manipulate the session instance (optional)
+   sf = Salesforce(
+      username='user@example.com', password='password', organizationId='OrgId',
+      session=session)
+
 Record Management
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,18 @@ from setuptools import setup
 import textwrap
 import sys
 
-extra_install_requires = []
-extra_tests_require = []
+pyver_install_requires = []
+pyver_tests_require = []
 if sys.version_info < (2, 7):
-    extra_install_requires.append('ordereddict>=1.1')
-    extra_tests_require.append('unittest2>=0.5.1')
+    pyver_install_requires.append('ordereddict>=1.1')
+    pyver_tests_require.append('unittest2>=0.5.1')
 
 if sys.version_info < (3, 0):
-    extra_tests_require.append('mock==1.0.1')
+    pyver_tests_require.append('mock==1.0.1')
 
 setup(
     name='simple-salesforce',
-    version='0.67.1',
+    version='0.68.0',
     author='Nick Catalano',
     packages=['simple_salesforce',],
     url='https://github.com/neworganizing/simple-salesforce',
@@ -26,11 +26,12 @@ setup(
     long_description=textwrap.dedent(open('README.rst', 'r').read()),
     install_requires=[
         'requests'
-    ] + extra_install_requires,
+    ] + pyver_install_requires,
     tests_require=[
         'nose>=1.3.0',
-        'pytz>=2014.1.1'
-    ] + extra_tests_require,
+        'pytz>=2014.1.1',
+        'httpretty>=0.8.10',
+    ] + pyver_tests_require,
     test_suite = 'nose.collector',
     keywords = "python salesforce salesforce.com",
     classifiers=[

--- a/simple_salesforce/tests/__init__.py
+++ b/simple_salesforce/tests/__init__.py
@@ -1,1 +1,46 @@
 """Simple-Salesforce Tests"""
+
+SESSION_ID = '12345'
+METADATA_URL = 'https://na15.salesforce.com/services/Soap/m/29.0/00Di0000000icUB'
+SERVER_URL = 'https://na15.salesforce.com/services/Soap/c/29.0/00Di0000000icUB/0DFi00000008UYO'
+
+LOGIN_RESPONSE_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="urn:enterprise.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <soapenv:Body>
+      <loginResponse>
+         <result>
+            <metadataServerUrl>%s</metadataServerUrl>
+            <passwordExpired>false</passwordExpired>
+            <sandbox>false</sandbox>
+            <serverUrl>%s</serverUrl>
+            <sessionId>%s</sessionId>
+            <userId>005i0000002MUqLAAW</userId>
+            <userInfo>
+               <accessibilityMode>false</accessibilityMode>
+               <currencySymbol>$</currencySymbol>
+               <orgAttachmentFileSizeLimit>5242880</orgAttachmentFileSizeLimit>
+               <orgDefaultCurrencyIsoCode>USD</orgDefaultCurrencyIsoCode>
+               <orgDisallowHtmlAttachments>false</orgDisallowHtmlAttachments>
+               <orgHasPersonAccounts>false</orgHasPersonAccounts>
+               <organizationId>00Di0000000icUBEAY</organizationId>
+               <organizationMultiCurrency>false</organizationMultiCurrency>
+               <organizationName>salesforce.com</organizationName>
+               <profileId>00ei0000001CMKcAAO</profileId>
+               <roleId xsi:nil="true" />
+               <sessionSecondsValid>7200</sessionSecondsValid>
+               <userDefaultCurrencyIsoCode xsi:nil="true" />
+               <userEmail>you@yourdomain.com</userEmail>
+               <userFullName>Wade Wegner</userFullName>
+               <userId>1234</userId>
+               <userLanguage>en_US</userLanguage>
+               <userLocale>en_US</userLocale>
+               <userName>you@yourdomain.com</userName>
+               <userTimeZone>America/Los_Angeles</userTimeZone>
+               <userType>Standard</userType>
+               <userUiSkin>Theme3</userUiSkin>
+            </userInfo>
+         </result>
+      </loginResponse>
+   </soapenv:Body>
+</soapenv:Envelope>
+""" % (METADATA_URL, SERVER_URL, SESSION_ID)


### PR DESCRIPTION
Allows for the injection of session objects created outside of
simple_salesforce, exposing some of the more advanced features of
requests and urllib3 to the user.

This fixes #71.