### PR TITLE
Fix version param

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info < (3, 0):
 
 setup(
     name='simple-salesforce',
-    version='0.68.0',
+    version='0.68.1',
     author='Nick Catalano',
     packages=['simple_salesforce',],
     url='https://github.com/neworganizing/simple-salesforce',

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -32,7 +32,7 @@ class Salesforce(object):
     def __init__(
             self, username=None, password=None, security_token=None,
             session_id=None, instance=None, instance_url=None,
-            organizationId=None, sandbox=False, sf_version=DEFAULT_API_VERSION,
+            organizationId=None, sandbox=False, version=DEFAULT_API_VERSION,
             proxies=None, session=None):
         """Initialize the instance with the given parameters.
 
@@ -65,7 +65,7 @@ class Salesforce(object):
         """
 
         # Determine if the user passed in the optional version and/or sandbox kwargs
-        self.sf_version = sf_version
+        self.sf_version = version
         self.sandbox = sandbox
         self.proxies = proxies
 

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -69,6 +69,25 @@ class TestSalesforce(unittest.TestCase):
         self.assertEqual(tests.SESSION_ID, sf.session_id)
         self.assertEqual(session, sf.request)
 
+    @httpretty.activate
+    def test_custom_version_success(self):
+        httpretty.register_uri(
+            httpretty.POST,
+            re.compile(r'^https://.*$'),
+            body=tests.LOGIN_RESPONSE_SUCCESS,
+            status=http.OK
+        )
+
+        # Use an invalid version that is guaranteed to never be used
+        expected_version = '4.2'
+        sf = Salesforce(
+            session=requests.Session(), username='foo@bar.com',
+            password='password', security_token='token',
+            version=expected_version)
+
+        self.assertEqual(
+            sf.base_url.split('/')[-2], 'v%s' % expected_version)
+
 
 class TestExceptionHandler(unittest.TestCase):
     """Test the exception router"""


### PR DESCRIPTION
The version param of Salesforce.__init__ was changed to sf_version. This
patch changes it back.