### PR TITLE
Add apex_request method to the client

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -390,7 +390,7 @@ class Salesforce(object):
         # so check whether there are more results and retrieve them if so.
         return get_all_results(result, **kwargs)
 
-    def apexecute(self, action, method='GET', data=None, **kwargs):
+    def apex_request(self, action, method='GET', data=None, **kwargs):
         """Makes an HTTP request to an APEX REST endpoint
 
         Arguments:
@@ -400,8 +400,22 @@ class Salesforce(object):
         * data -- A dict of parameters to send in a POST / PUT request
         * kwargs -- Additional kwargs to pass to `requests.request`
         """
-        result = self._call_salesforce(method, self.apex_url + action,
-                                       data=json.dumps(data), **kwargs)
+        return self._call_salesforce(method, self.apex_url + action,
+                                     data=json.dumps(data), **kwargs)
+
+    def apexecute(self, action, method='GET', data=None, **kwargs):
+        """Makes an HTTP request to an APEX REST endpoint and returns
+        the resulting body content
+
+        Arguments:
+
+        * action -- The REST endpoint for the request.
+        * method -- HTTP method for the request (default GET)
+        * data -- A dict of parameters to send in a POST / PUT request
+        * kwargs -- Additional kwargs to pass to `requests.request`
+        """
+        result = self.apex_execute(method, self.apex_url + action,
+                                   data=data, **kwargs)
 
         if result.status_code == 200:
             try:

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -91,6 +91,37 @@ class TestSalesforce(unittest.TestCase):
         self.assertEqual(
             client.base_url.split('/')[-2], 'v%s' % expected_version)
 
+    @httpretty.activate
+    def test_apex_request(self):
+        """Test apex request"""
+
+        # Mock the response for the login call
+        httpretty.register_uri(
+            httpretty.POST,
+            re.compile(r'^https://.*$'),
+            body=tests.LOGIN_RESPONSE_SUCCESS,
+            status=http.OK
+        )
+
+        # Mock the response for the Apex call
+        apex_response = '{"foo": "bar"}'
+        httpretty.register_uri(
+            httpretty.GET,
+            re.compile(r'^https://.*$'),
+            body=apex_response,
+            status=http.OK
+        )
+
+        client = Salesforce(
+            session=requests.Session(), username='foo@bar.com',
+            password='password', security_token='token')
+
+        result = client.apex_request('foo', 'GET')
+
+        self.assertIsInstance(result, requests.models.Response)
+        self.assertEqual(result.status_code, http.OK)
+        self.assertEqual(result.text, apex_response)
+
 
 class TestExceptionHandler(unittest.TestCase):
     """Test the exception router"""


### PR DESCRIPTION
We have some Apex calls that can return non-200 status codes, but the current version of the client discards the Apex response if it returns anything other than a 200. This PR adds a new method `apex_request()` which returns the full response object (which we'll be able to use), and modifies the existing `apexecute()` to use it but still work in the same way as it does now. 

Test output:

```bash
running test
Searching for mock==1.0.1
Best match: mock 1.0.1
Processing mock-1.0.1-py2.7.egg

Using /data/workspace/simple-salesforce/.eggs/mock-1.0.1-py2.7.egg
Searching for nose>=1.3.0
Best match: nose 1.3.7
Processing nose-1.3.7-py2.7.egg

Using /data/workspace/simple-salesforce/.eggs/nose-1.3.7-py2.7.egg
running egg_info
writing requirements to simple_salesforce.egg-info/requires.txt
writing simple_salesforce.egg-info/PKG-INFO
writing top-level names to simple_salesforce.egg-info/top_level.txt
writing dependency_links to simple_salesforce.egg-info/dependency_links.txt
reading manifest file 'simple_salesforce.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'simple_salesforce.egg-info/SOURCES.txt'
running build_ext
test_expired_session (simple_salesforce.tests.test_api.TestExceptionHandler)
Test an expired session (401 code) ... ok
test_generic_error_code (simple_salesforce.tests.test_api.TestExceptionHandler)
Test an error code that is otherwise not caught ... ok
test_malformed_request (simple_salesforce.tests.test_api.TestExceptionHandler)
Test a malformed request (400 code) ... ok
test_multiple_records_returned (simple_salesforce.tests.test_api.TestExceptionHandler)
Test multiple records returned (a 300 code) ... ok
test_request_refused (simple_salesforce.tests.test_api.TestExceptionHandler)
Test a refused request (403 code) ... ok
test_resource_not_found (simple_salesforce.tests.test_api.TestExceptionHandler)
Test resource not found (404 code) ... ok
test_apex_request (simple_salesforce.tests.test_api.TestSalesforce)
Test apex request ... ok
test_custom_session_success (simple_salesforce.tests.test_api.TestSalesforce)
Ensure custom session is used ... ok
test_custom_version_success (simple_salesforce.tests.test_api.TestSalesforce)
Test custom version ... ok
test_custom_session_success (simple_salesforce.tests.test_login.TestSalesforceLogin)
Test custom session ... ok
test_failure (simple_salesforce.tests.test_login.TestSalesforceLogin)
Test A Failed Login Response ... ok
test_date_to_iso8601 (simple_salesforce.tests.test_util.TestXMLParser)
Test date converstion ... ok
test_returns_valid_value (simple_salesforce.tests.test_util.TestXMLParser)
Test that when given the correct XML a valid response is returned ... ok

----------------------------------------------------------------------
Ran 13 tests in 0.120s

OK
```